### PR TITLE
Bootstrap input_group component

### DIFF
--- a/lib/generators/simple_form/install_generator.rb
+++ b/lib/generators/simple_form/install_generator.rb
@@ -20,6 +20,8 @@ module SimpleForm
 
         if options[:bootstrap]
           template "config/initializers/simple_form_bootstrap.rb"
+          template "lib/components/input_group_component.rb"
+          uncomment_lines 'config/initializers/simple_form.rb', /lib\/components/
         elsif options[:foundation]
           template "config/initializers/simple_form_foundation.rb"
         end

--- a/lib/generators/simple_form/templates/lib/components/input_group_component.rb
+++ b/lib/generators/simple_form/templates/lib/components/input_group_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# custom component requires input group wrapper
+module InputGroup
+  def prepend(wrapper_options = nil)
+    template.content_tag(:span, options[:prepend], class: 'input-group-text') if options[:prepend]
+  end
+
+  def append(wrapper_options = nil)
+    template.content_tag(:span, options[:append], class: 'input-group-text') if options[:append]
+  end
+end
+
+# Register the component in Simple Form.
+SimpleForm.include_component(InputGroup)


### PR DESCRIPTION
Thank you for [simple_form PR with bootstrap5 configuration](https://github.com/heartcombo/simple_form/pull/1738). While using it I discovered one issue connected with `input_group` wrapper (https://simple-form-bootstrap.herokuapp.com/examples/input_group). It requires custom component (`lib/components/input_group_component.rb`). 

This PR adds missing component and turns on loading custom components in the simple form initializer.